### PR TITLE
...

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ _"I want green here, but which green?" -> colours -> "oooo ok that one"_
 The workflow that just works.
 
 ---
+
 ## License
 
-`@gesslar/colours` is released into the public domain under the [0BSD](LICENSE.txt).
+`@gesslar/colours` is released under the [0BSD](LICENSE.txt).


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two small documentation improvements to `README.md`:

- Adds a blank line before the `## License` heading for consistent Markdown formatting
- Corrects the license description by removing the phrase "into the public domain" — the 0BSD license is a permissive open-source license, not technically a public domain dedication, so the updated wording is more accurate

Both changes are non-functional and improve the clarity and formatting of the documentation.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it contains only minor, correct documentation improvements.

The changes are purely cosmetic and factual corrections to the README. The license wording fix is actually more accurate (0BSD is not a public domain dedication), and the blank line is a standard Markdown formatting improvement. No code is affected.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["..."](https://github.com/gesslar/colours/commit/c5f69e95a3523bf15411b3f5f07982e5aaa4dbb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27957261)</sub>

<!-- /greptile_comment -->