### PR TITLE
update workflow

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -2,16 +2,13 @@ name: Release
 
 on:
   pull_request:
-    types: [closed]
-    branches: [main]
+    types: [ closed ]
+    branches: [ main ]
 
 jobs:
   Release:
     if: ${{ github.event.pull_request.merged == true }}
     uses: gesslar/Maint/.github/workflows/Release.yaml@main
     secrets: inherit
-    with:
-      package_manager: "auto"
-      quality_check: "Quality"
     permissions:
       contents: write


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `Release.yaml` by removing the `with:` block (which previously passed `package_manager: "auto"` and `quality_check: "Quality"` to the reusable workflow) and applies minor cosmetic formatting to the trigger arrays (adding spaces inside brackets). The workflow continues to correctly reference `gesslar/Maint/.github/workflows/Release.yaml@main`, in compliance with the repository's policy of targeting `@main` for Release and Quality workflows.

- Removed `with: package_manager: "auto"` and `quality_check: "Quality"` inputs — the reusable workflow at `@main` is expected to supply defaults or no longer requires these inputs
- Cosmetic whitespace change: `[closed]` → `[ closed ]`, `[main]` → `[ main ]`
- Workflow ref remains `@main` as required by project convention

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is intentional, minimal, and compliant with the @main targeting policy.

The only functional change is dropping two `with:` inputs from the reusable workflow call. This is clearly deliberate (likely reflecting upstream changes to the reusable workflow's defaults or interface). The `@main` reference is correct per the custom instruction. No logic errors or security concerns were identified.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into update-workflow"](https://github.com/gesslar/colours/commit/bba74798bc3a77700adb365eb2ed60f2dd9867be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28735207)</sub>

**Context used:**

- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/review/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))

<!-- /greptile_comment -->